### PR TITLE
Use homebrew and ubuntu for linting

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -20,22 +20,17 @@ jobs:
         uses: Homebrew/actions/setup-homebrew@master
       - name: Install ShellCheck
         run: brew install shellcheck
-      - name: Check ShellCheck version
-        run: shellcheck --version
       - name: Shellcheck
         run: shellcheck -x bin/* -P lib/
 
   shfmt:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
       - name: Set up Homebrew
         uses: Homebrew/actions/setup-homebrew@master
-
       - name: Install shfmt
         run: brew install shfmt
-
       - name: Run shfmt
         run: shfmt -d -i 2 -ci .

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -16,22 +16,23 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
-      - name: Update Shellcheck
-        run: |
-          sudo apt install xz-utils
-          scversion="stable"
-          wget -qO- "https://github.com/koalaman/shellcheck/releases/download/${scversion?}/shellcheck-${scversion?}.linux.x86_64.tar.xz" | tar -xJv
-          sudo cp "shellcheck-${scversion}/shellcheck" /usr/bin/
-          shellcheck --version
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+      - name: Install ShellCheck
+        run: brew install shellcheck
+      - name: Check ShellCheck version
+        run: shellcheck --version
       - name: Shellcheck
         run: shellcheck -x bin/* -P lib/
 
   shfmt:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@master
 
       - name: Install shfmt
         run: brew install shfmt


### PR DESCRIPTION
Standardize lint jobs to use Homebrew for dependency installation and run on `ubuntu-latest`.

---
<a href="https://cursor.com/background-agent?bcId=bc-d35f7c5e-5596-47ec-bac1-c36cba3e4b24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d35f7c5e-5596-47ec-bac1-c36cba3e4b24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Install ShellCheck and shfmt via Homebrew and run both lint jobs on ubuntu-latest.
> 
> - **CI** (`.github/workflows/lint.yaml`):
>   - **Shellcheck**:
>     - Replace manual install script with Homebrew (`setup-homebrew` + `brew install shellcheck`).
>   - **shfmt**:
>     - Change runner from `macos-latest` to `ubuntu-latest`.
>     - Add Homebrew setup and install `shfmt` via `brew`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 48bf0f31bbc981c96ad88cb2e47e6680ef8b5f63. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->